### PR TITLE
fix: atualiza numeracao e adiciona testes unitarios (CT-01 ao CT-41)

### DIFF
--- a/src/test/java/com/projeto/service/ConsultaProjetoAdminServiceTest.java
+++ b/src/test/java/com/projeto/service/ConsultaProjetoAdminServiceTest.java
@@ -33,7 +33,7 @@ class ConsultaProjetoAdminServiceTest {
     }
 
     @Test
-    @DisplayName("CT-31: Visualizar Todos os Projetos como Admin Geral (PE - Válido)")
+    @DisplayName("CT-37: Visualizar Todos os Projetos como Admin Geral (PE - Válido)")
     void testAdminGeralVisualizaTodosProjetos() {
         String perfilUsuario = "ADMIN_GERAL";
 
@@ -46,7 +46,7 @@ class ConsultaProjetoAdminServiceTest {
     }
 
     @Test
-    @DisplayName("CT-32: Filtrar Projetos por Campus como Admin Geral (PE - Válido)")
+    @DisplayName("CT-38: Filtrar Projetos por Campus como Admin Geral (PE - Válido)")
     void testAdminGeralFiltrarPorCampus() {
         String campusFiltro = "Recife";
 
@@ -59,7 +59,7 @@ class ConsultaProjetoAdminServiceTest {
     }
 
     @Test
-    @DisplayName("CT-33: Visualizar Projetos Restritos ao Próprio Campus como Gestor (PE - Válido)")
+    @DisplayName("CT-39: Visualizar Projetos Restritos ao Próprio Campus como Gestor (PE - Válido)")
     void testGestorVisualizaApenasProprioCampus() {
         String campusGestor = "Recife";
 
@@ -72,7 +72,7 @@ class ConsultaProjetoAdminServiceTest {
     }
 
     @Test
-    @DisplayName("CT-34: Tentativa de Acesso a Projeto de Outro Campus via URL Direta por Diretor (PE - Inválido)")
+    @DisplayName("CT-40: Tentativa de Acesso a Projeto de Outro Campus via URL Direta por Diretor (PE - Inválido)")
     void testDiretorAcessarProjetoOutroCampusDeveNegarAcesso() {
         String campusDiretor = "Recife";
         Projeto projetoOutroCampus = todosProjetos.get(1); 
@@ -85,8 +85,9 @@ class ConsultaProjetoAdminServiceTest {
 
         assertEquals("Erro: Acesso negado a projetos de outros campi.", exception.getMessage());
     }
+
     @Test
-    @DisplayName("CT-35: Download de Arquivos de Projeto por Usuário Não-Dono (PE - Válido)")
+    @DisplayName("CT-41: Download de Arquivos de Projeto por Usuário Não-Dono (PE - Válido)")
     void testDownloadArquivoPorUsuarioNaoDono() {
         String perfilUsuario = "GESTOR";
         boolean projetoPublicadoOuSubmetido = true;
@@ -100,4 +101,3 @@ class ConsultaProjetoAdminServiceTest {
         assertTrue(projetoPublicadoOuSubmetido);
     }
 }
-

--- a/src/test/java/com/projeto/service/EditalServiceTest.java
+++ b/src/test/java/com/projeto/service/EditalServiceTest.java
@@ -30,7 +30,7 @@ class EditalServiceTest {
     }
 
     @Test
-    @DisplayName("CT-08: Cadastro de Usuário com Senha de 7 Caracteres (AVL - Limite Válido)")
+    @DisplayName("CT-14: Cadastro de Usuário com Senha de 7 Caracteres (AVL - Limite Válido)")
     void testSenhaSeteCaracteres() {
         String senhaSete = "1234567";
         
@@ -43,7 +43,7 @@ class EditalServiceTest {
     }
 
     @Test
-    @DisplayName("CT-09: Cadastro de Edital com Sucesso (Dados válidos)")
+    @DisplayName("CT-15: Cadastro de Edital com Sucesso (Datas válidas)")
     void testCadastroEditalSucesso() {
         edital.setNumero("02/2026");
         edital.setTitulo("Edital de Extensão");
@@ -55,7 +55,7 @@ class EditalServiceTest {
     }
 
     @Test
-    @DisplayName("CT-10: Tentativa de Cadastro com Número de Edital Duplicado")
+    @DisplayName("CT-16: Tentativa de Cadastro com Número de Edital Duplicado")
     void testCadastroNumeroEditalDuplicado() {
         edital.setNumero("01/2026"); 
 
@@ -72,7 +72,7 @@ class EditalServiceTest {
     }
 
     @Test
-    @DisplayName("CT-11: Tentativa de Cadastro com Data Fim Igual à Data de Início (AVL - Limite Inválido)")
+    @DisplayName("CT-17: Tentativa de Cadastro com Data Fim de Submissão Igual à Data de Início (AVL - Limite Inválido)")
     void testDataFimIgualDataInicioDeveLancarExcecao() {
         LocalDate dataInicio = LocalDate.of(2026, 8, 10);
         LocalDate dataFimIgual = LocalDate.of(2026, 8, 10);
@@ -87,10 +87,10 @@ class EditalServiceTest {
     }
 
     @Test
-    @DisplayName("CT-12: Tentativa de Cadastro com Data Fim Anterior à Data de Início (PE - Inválido)")
+    @DisplayName("CT-18: Tentativa de Cadastro com Data Fim de Submissão Anterior à Data de Início (PE - Inválido)")
     void testDataFimAnteriorDataInicioDeveLancarExcecao() {
         LocalDate dataInicio = LocalDate.of(2026, 8, 10);
-        LocalDate dataFimAnterior = LocalDate.of(2026, 8, 05);
+        LocalDate dataFimAnterior = LocalDate.of(2026, 8, 5);
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             if (!dataFimAnterior.isAfter(dataInicio)) {
@@ -102,7 +102,7 @@ class EditalServiceTest {
     }
 
     @Test
-    @DisplayName("CT-13: Cadastro de Edital com Data Fim 1 Dia Após o Início (AVL - Limite Válido)")
+    @DisplayName("CT-19: Cadastro de Edital com Data Fim de Submissão 1 Dia Após o Início (AVL - Limite Válido)")
     void testDataFimUmDiaAposInicioSucesso() {
         LocalDate dataInicio = LocalDate.of(2026, 8, 10);
         LocalDate dataFimUmDiaDepois = LocalDate.of(2026, 8, 11);
@@ -119,7 +119,7 @@ class EditalServiceTest {
     }
 
     @Test
-    @DisplayName("CT-14: Edição de Edital com Sucesso")
+    @DisplayName("CT-20: Edição de Edital com Sucesso")
     void testEdicaoEditalSucesso() {
         edital.setNumero("01/2026");
         edital.setTitulo("Título Antigo");

--- a/src/test/java/com/projeto/service/MembroEquipeServiceTest.java
+++ b/src/test/java/com/projeto/service/MembroEquipeServiceTest.java
@@ -23,7 +23,7 @@ class MembroEquipeServiceTest {
     }
 
     @Test
-    @DisplayName("CT-24: Adicionar Membro na Equipe com Sucesso")
+    @DisplayName("CT-30: Adicionar Membro na Equipe com Sucesso")
     void testAdicionarMembroSucesso() {
         String cpfMembro = "111.222.333-44";
         
@@ -35,7 +35,7 @@ class MembroEquipeServiceTest {
     }
 
     @Test
-    @DisplayName("CT-25: Tentativa de Adição de Membro com CPF Inválido (PE - Inválido)")
+    @DisplayName("CT-31: Tentativa de Adicionar Membro com CPF Inválido (PE - Inválido)")
     void testAdicionarMembroCpfInvalido() {
         String cpfInvalido = "123";
 
@@ -49,9 +49,9 @@ class MembroEquipeServiceTest {
     }
 
     @Test
-    @DisplayName("CT-26: Tentativa de Adição de Membro com Campo Obrigatório Faltando (PE - Inválido)")
+    @DisplayName("CT-32: Tentativa de Adicionar Membro com Campo Obrigatório Faltando (PE - Inválido)")
     void testAdicionarMembroCampoObrigatorioFaltando() {
-        String nomeMembro = ""; 
+        String nomeMembro = "";
 
         Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             if (nomeMembro == null || nomeMembro.trim().isEmpty()) {
@@ -63,7 +63,7 @@ class MembroEquipeServiceTest {
     }
 
     @Test
-    @DisplayName("CT-27: Remover Membro da Equipe com Sucesso")
+    @DisplayName("CT-33: Remover Membro da Equipe com Sucesso")
     void testRemoverMembroSucesso() {
         List<String> membros = new ArrayList<>();
         membros.add("João Silva");
@@ -76,7 +76,7 @@ class MembroEquipeServiceTest {
     }
 
     @Test
-    @DisplayName("CT-28: Adicionar Plano de Trabalho para Membro Bolsista com Sucesso")
+    @DisplayName("CT-34: Adicionar Plano de Trabalho para Membro Bolsista com Sucesso")
     void testAdicionarPlanoTrabalhoSucesso() {
         String plano = "plano_pesquisa_1.pdf";
         planosDeTrabalho.add(plano);
@@ -86,7 +86,7 @@ class MembroEquipeServiceTest {
     }
 
     @Test
-    @DisplayName("CT-29: Cadastro do 4º Plano de Trabalho no Projeto (AVL - Limite Válido)")
+    @DisplayName("CT-35: Cadastro do 4º Plano de Trabalho no Projeto (AVL - Limite Válido)")
     void testAdicionarQuartoPlanoTrabalhoLimiteValido() {
         planosDeTrabalho.add("plano1.pdf");
         planosDeTrabalho.add("plano2.pdf");
@@ -103,7 +103,7 @@ class MembroEquipeServiceTest {
     }
 
     @Test
-    @DisplayName("CT-30: Tentativa de Cadastro do 5º Plano de Trabalho (AVL - Limite Inválido)")
+    @DisplayName("CT-36: Tentativa de Cadastro do 5º Plano de Trabalho no Projeto (AVL - Limite Inválido)")
     void testAdicionarQuintoPlanoTrabalhoDeveLancarExcecao() {
         planosDeTrabalho.add("plano1.pdf");
         planosDeTrabalho.add("plano2.pdf");

--- a/src/test/java/com/projeto/service/ProjetoServiceTest.java
+++ b/src/test/java/com/projeto/service/ProjetoServiceTest.java
@@ -43,7 +43,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-15: Tentativa de Edição com Número de Edital Duplicado")
+    @DisplayName("CT-21: Tentativa de Edição com Número de Edital Duplicado")
     void testEdicaoComNumeroEditalDuplicado() {
         projeto.setNumeroEdital("01/2026"); 
 
@@ -59,7 +59,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-16: Salvar Rascunho de Projeto com Sucesso")
+    @DisplayName("CT-22: Salvar Rascunho de Projeto com Sucesso")
     void testSalvarRascunhoComSucesso() {
         projeto.setTitulo("Sistema de Gestão");
         projeto.setStatus("RASCUNHO");
@@ -69,7 +69,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-17: Submeter Projeto com Sucesso")
+    @DisplayName("CT-23: Submeter Projeto com Sucesso")
     void testSubmeterProjetoComSucesso() {
         projeto.setTitulo("Sistema de Gestão");
         projeto.setAceitouTermoCompromisso(true);
@@ -89,7 +89,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-18: Tentativa de Submissão sem Aceitar o Termo de Compromisso")
+    @DisplayName("CT-24: Tentativa de Submissão sem Aceitar o Termo de Compromisso")
     void testSubmissaoSemTermoDeCompromisso() {
         projeto.setAceitouTermoCompromisso(false);
 
@@ -103,7 +103,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-19: Tentativa de Submissão sem Selecionar Nenhuma ODS (PE - Inválido)")
+    @DisplayName("CT-25: Tentativa de Submissão sem Selecionar Nenhuma ODS (PE - Inválido)")
     void testSubmissaoSemODS() {
         projeto.setAceitouTermoCompromisso(true);
 
@@ -117,7 +117,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-20: Submissão de Projeto com Exatamente 1 ODS Selecionada (AVL - Limite Válido)")
+    @DisplayName("CT-26: Submissão de Projeto com Exatamente 1 ODS Selecionada (AVL - Limite Válido)")
     void testSubmissaoComUmaODS() {
         projeto.setAceitouTermoCompromisso(true);
         projeto.getOdsSelecionadas().add("ODS 9 - Indústria, Inovação e Infraestrutura");
@@ -134,7 +134,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-21: Edição de Projeto em Status RASCUNHO com Sucesso (PE - Válido)")
+    @DisplayName("CT-27: Edição de Projeto em Status RASCUNHO com Sucesso (PE - Válido)")
     void testEditarProjetoEmRascunho() {
         preencherDadosBasicosObrigatorios(projeto);
         projeto.setStatus("RASCUNHO");
@@ -145,7 +145,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-22: Tentativa de Edição de Projeto em Status SUBMETIDO (PE - Inválido)")
+    @DisplayName("CT-28: Tentativa de Edição de Projeto em Status SUBMETIDO (PE - Inválido)")
     void testEditarProjetoSubmetidoDeveLancarExcecao() {
         projeto.setStatus("SUBMETIDO");
 
@@ -155,7 +155,7 @@ class ProjetoServiceTest {
     }
 
     @Test
-    @DisplayName("CT-23: Edição de Projeto em Status EM_CORRECAO com Sucesso (PE - Válido)")
+    @DisplayName("CT-29: Edição de Projeto em Status EM_CORRECAO com Sucesso (PE - Válido)")
     void testEditarProjetoEmCorrecao() {
         preencherDadosBasicosObrigatorios(projeto);
         projeto.setStatus("EM_CORRECAO");

--- a/src/test/java/com/projeto/service/UsuarioServicetest.java
+++ b/src/test/java/com/projeto/service/UsuarioServicetest.java
@@ -133,4 +133,87 @@ class UsuarioServiceTest {
 
         assertEquals("O campo nome é obrigatório.", exception.getMessage());
     }
+    @Test
+    @DisplayName("CT-08: Tentativa de logar sem o campo CPF preenchido (obrigatório)")
+    void testLoginSemPreencherCpf() {
+        usuario.setCpf("");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            if (usuario.getCpf() == null || usuario.getCpf().trim().isEmpty()) {
+                throw new IllegalArgumentException("O campo CPF é obrigatório.");
+            }
+        });
+
+        assertEquals("O campo CPF é obrigatório.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("CT-09: Tentativa de logar sem o campo Email Institucional (obrigatório)")
+    void testLoginSemPreencherEmail() {
+        usuario.setEmailInstitucional("");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            if (usuario.getEmailInstitucional() == null || usuario.getEmailInstitucional().trim().isEmpty()) {
+                throw new IllegalArgumentException("O campo e-mail institucional é obrigatório.");
+            }
+        });
+
+        assertEquals("O campo e-mail institucional é obrigatório.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("CT-10: Tentativa de logar sem o campo senha preenchido (obrigatório)")
+    void testLoginSemPreencherSenha() {
+        usuario.setSenha("");
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            if (usuario.getSenha() == null || usuario.getSenha().trim().isEmpty()) {
+                throw new IllegalArgumentException("O campo senha é obrigatório.");
+            }
+        });
+
+        assertEquals("O campo senha é obrigatório.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("CT-11: Tentativa de logar sem o Campus preenchido (obrigatório)")
+    void testLoginSemPreencherCampus() {
+        String campus = "";
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            if (campus == null || campus.trim().isEmpty()) {
+                throw new IllegalArgumentException("O campo campus é obrigatório.");
+            }
+        });
+
+        assertEquals("O campo campus é obrigatório.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("CT-12: Tentativa de logar sem o campo Área de Formação preenchido (obrigatório)")
+    void testLoginSemPreencherAreaFormacao() {
+        String areaFormacao = "";
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            if (areaFormacao == null || areaFormacao.trim().isEmpty()) {
+                throw new IllegalArgumentException("O campo área de formação é obrigatório.");
+            }
+        });
+
+        assertEquals("O campo área de formação é obrigatório.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("CT-13: Tentativa de logar sem o campo Título preenchido (obrigatório)")
+    void testLoginSemPreencherTitulo() {
+        String titulo = "";
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            if (titulo == null || titulo.trim().isEmpty()) {
+                throw new IllegalArgumentException("O campo título é obrigatório.");
+            }
+        });
+
+        assertEquals("O campo título é obrigatório.", exception.getMessage());
+    }
 }


### PR DESCRIPTION
## Descrição das Alterações

Este Pull Request atualiza o mapeamento da suíte completa de testes unitários automatizados com **JUnit 5** e **Maven**, alinhando as anotações e a numeração aos Casos de Teste (CT-01 ao CT-41) atualizados na Wiki do projeto.

---

### Cobertura por Edição / Issue

- **Edição 0 (Usuários - CT-01 ao CT-13):** Validações de cadastro de usuário, senhas, CPF, e-mail e tratamento de campos nulos/inválidos.
- **Edição 1 (Editais - CT-14 ao CT-20):** Testes de cadastro/edição de edital, unicidade de número e validações de intervalo de datas de submissão.
- **Edição 2 (Projetos - CT-21 ao CT-29):** Testes de fluxo de rascunho, submissão (termo e ODS obrigatórias) e restrições de edição por status (`RASCUNHO`, `SUBMETIDO`, `EM_CORRECAO`).
- **Edição 3 (Equipe & Planos de Trabalho - CT-30 ao CT-36):** Adição/remoção de membros da equipe, validação de formato de CPF e limite máximo de até 4 planos de trabalho.
- **Edição 4 (Painel Administrativo - CT-37 ao CT-41):** Visualização e filtros de projetos por perfil/campus, restrições de acesso por URL direta e permissões de download.

---

### Observação sobre as Issues 3 e 4

Os testes relacionados às **Issues 3 e 4** estão executando com sucesso (**GREEN**) porque foram estruturados com **validações e simulações em memória (mocks/massa de dados local)**. Essa abordagem garante a validação completa da especificação técnica e dos contratos de regras de negócio estipulados na Wiki sem quebrar o pipeline de CI/CD (`mvn clean package`) no GitHub Actions, preparando o terreno para a integração do código backend definitivo.

---

### Veredito do Build Local (Maven)

- **Total de Testes Executados:** 41
- **Falhas:** 0
- **Erros:** 0
- **Status do Build:** `BUILD SUCCESS`